### PR TITLE
Computer Phrasing Edits

### DIFF
--- a/code/game/machinery/computer/card.dm
+++ b/code/game/machinery/computer/card.dm
@@ -35,7 +35,15 @@ var/time_last_changed_position = 0
 		"Chief Engineer",
 		"Research Director",
 		"Chief Medical Officer",
-		"Chaplain")
+		"Chaplain",
+		"Detective",
+		"Legion Recruit",
+		"Legion Decan",
+		"Legion Vexillarius",
+		"Legion Centurion",
+		"Legion Legat",
+		"Overseer",
+		"Ranger")
 
 	//The scaling factor of max total positions in relation to the total amount of people on board the station in %
 	var/max_relative_positions = 30 //30%: Seems reasonable, limit of 6 @ 20 players

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -205,12 +205,12 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 				if(CM.lastTimeUsed + 600 < world.time)
 					usr << "Arrays recycling.  Please stand by."
 					return
-				var/input = stripped_input(usr, "Please choose a message to transmit to Centcom via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response.", "Send a message to Centcomm.", "")
+				var/input = stripped_input(usr, "Please choose a message to transmit to Vault-Tec via quantum entanglement.  Please be aware that this process is very expensive, and abuse will lead to... termination.  Transmission does not guarantee a response.", "Send a message to Vault-Tec.", "")
 				if(!input || !(usr in view(1,src)))
 					return
 				Centcomm_announce(input, usr)
 				usr << "Message transmitted."
-				log_say("[key_name(usr)] has made a Centcom announcement: [input]")
+				log_say("[key_name(usr)] has made a Vault-Tec announcement: [input]")
 				CM.lastTimeUsed = world.time
 
 
@@ -243,7 +243,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 					return
 				Nuke_request(input, usr)
 				usr << "Request sent."
-				log_say("[key_name(usr)] has requested the nuclear codes from Centcomm")
+				log_say("[key_name(usr)] has requested the nuclear codes from Vault-Tec")
 				priority_announce("The codes for the on-station nuclear self-destruct have been requested by [usr]. Confirmation or denial of this request will be sent shortly.", "Nuclear Self Destruct Codes Requested",'sound/AI/commandreport.ogg')
 				CM.lastTimeUsed = world.time
 
@@ -389,7 +389,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 					dat += "<BR>\[ <A HREF='?src=\ref[src];operation=emergencyaccess'>Emergency Maintenance Access</A> \]"
 					dat += "<BR>\[ <A HREF='?src=\ref[src];operation=nukerequest'>Request Nuclear Authentication Codes</A> \]"
 					if(src.emagged == 0)
-						dat += "<BR>\[ <A HREF='?src=\ref[src];operation=MessageCentcomm'>Send Message to Centcom</A> \]"
+						dat += "<BR>\[ <A HREF='?src=\ref[src];operation=MessageCentcomm'>Send Message to Vault-Tec</A> \]"
 					else
 						dat += "<BR>\[ <A HREF='?src=\ref[src];operation=MessageSyndicate'>Send Message to \[UNKNOWN\]</A> \]"
 						dat += "<BR>\[ <A HREF='?src=\ref[src];operation=RestoreBackup'>Restore Backup Routing Data</A> \]"


### PR DESCRIPTION
Removing refrences to CentComm, and removing legion job slots from the
edit slots list in the ID computer.
